### PR TITLE
docs(adr): backfill ADR-0008 (Janus relay) and ADR-0009 (frontend stack)

### DIFF
--- a/docs/architecture/09-decisions.md
+++ b/docs/architecture/09-decisions.md
@@ -4,15 +4,17 @@ Architecture decisions are recorded as Architecture Decision Records (ADRs) in M
 
 ## ADR Index
 
-| ID                                                            | Title                                                       | Status   | Date       |
-| ------------------------------------------------------------- | ----------------------------------------------------------- | -------- | ---------- |
-| [ADR-0001](../decisions/ADR-0001-docker-single-container.md)  | Docker Single-Container Model (One Container = One Printer) | Accepted | 2026-04-13 |
-| [ADR-0002](../decisions/ADR-0002-octoprint-agent-identity.md) | OctoPrint Agent Identity for Obico WebSocket                | Accepted | 2026-04-13 |
-| [ADR-0003](../decisions/ADR-0003-http-digest-auth.md)         | HTTP Digest Authentication for PrusaLink API                | Accepted | 2026-04-13 |
-| [ADR-0004](../decisions/ADR-0004-rtsp-ffmpeg-camera.md)       | RTSP Camera Stream via ffmpeg                               | Accepted | 2026-04-13 |
-| [ADR-0005](../decisions/ADR-0005-circuit-breaker-pattern.md)  | Circuit Breaker Pattern for External Component Resilience   | Accepted | 2026-04-13 |
-| [ADR-0006](../decisions/ADR-0006-config-on-volume.md)         | Configuration Stored as JSON File on Docker Volume          | Accepted | 2026-04-13 |
-| [ADR-0007](../decisions/ADR-0007-mit-license.md)              | MIT License for Open-Source Release                         | Accepted | 2026-04-13 |
+| ID                                                            | Title                                                               | Status   | Date       |
+| ------------------------------------------------------------- | ------------------------------------------------------------------- | -------- | ---------- |
+| [ADR-0001](../decisions/ADR-0001-docker-single-container.md)  | Docker Single-Container Model (One Container = One Printer)         | Accepted | 2026-04-13 |
+| [ADR-0002](../decisions/ADR-0002-octoprint-agent-identity.md) | OctoPrint Agent Identity for Obico WebSocket                        | Accepted | 2026-04-13 |
+| [ADR-0003](../decisions/ADR-0003-http-digest-auth.md)         | HTTP Digest Authentication for PrusaLink API                        | Accepted | 2026-04-13 |
+| [ADR-0004](../decisions/ADR-0004-rtsp-ffmpeg-camera.md)       | RTSP Camera Stream via ffmpeg                                       | Accepted | 2026-04-13 |
+| [ADR-0005](../decisions/ADR-0005-circuit-breaker-pattern.md)  | Circuit Breaker Pattern for External Component Resilience           | Accepted | 2026-04-13 |
+| [ADR-0006](../decisions/ADR-0006-config-on-volume.md)         | Configuration Stored as JSON File on Docker Volume                  | Accepted | 2026-04-13 |
+| [ADR-0007](../decisions/ADR-0007-mit-license.md)              | MIT License for Open-Source Release                                 | Accepted | 2026-04-13 |
+| [ADR-0008](../decisions/ADR-0008-janus-webrtc-relay.md)       | Janus WebRTC Relay for Live Stream in Obico Control Panel           | Accepted | 2026-04-30 |
+| [ADR-0009](../decisions/ADR-0009-frontend-stack.md)           | Frontend Stack — React 19 + Vite + Mantine + react-router + i18next | Accepted | 2026-04-30 |
 
 ## Decision Process
 

--- a/docs/decisions/ADR-0008-janus-webrtc-relay.md
+++ b/docs/decisions/ADR-0008-janus-webrtc-relay.md
@@ -1,0 +1,70 @@
+# ADR-0008: Janus WebRTC Relay for Live Stream in Obico Control Panel
+
+## Status
+
+Accepted
+
+## Context and Problem Statement
+
+Obico's control panel renders the printer's live camera feed for users. Two paths exist for delivering the camera stream from SentryBridge to Obico:
+
+1. **MJPEG snapshot upload** — JPEG frames POSTed to Obico over HTTP (already implemented for AI failure detection, max 10s interval).
+2. **Low-latency live video** — required for the interactive live stream Obico shows in its control panel.
+
+MJPEG alone is insufficient for the live-stream UX: latencies of multiple seconds and jitter from per-frame HTTP uploads make the feed unsuitable for "watch the printer in real time" use cases. Obico's reference agents (Moonraker-Obico, OctoPrint Obico Plugin) integrate a WebRTC stream via Janus for this purpose; the Obico control panel expects a Janus WebSocket relay to be reachable.
+
+How should SentryBridge deliver the live stream to Obico?
+
+## Decision Drivers
+
+- **Parity with Obico reference agents** — the Obico control panel client signals via a `/ws/janus/{id}/` WebSocket; without that endpoint, the live stream UI does not work.
+- **Latency** — sub-second video for monitoring active prints; MJPEG cannot reach this.
+- **One-container constraint** (ADR-0001) — adding an external service is acceptable only if it can be co-located in the same Docker image.
+- **LAN deployment target** — users already need Docker; adding another binary inside the container is acceptable. Users should not have to run a separate Janus container for the basic case.
+- **ARM64 + AMD64 support** — Janus must build/run on both architectures (Alpine package available).
+- **No protocol invention** — SentryBridge follows existing Obico WebSocket message formats (reverse-engineered from open-source reference agents); inventing a custom video transport would break compatibility.
+
+## Considered Options
+
+1. **MJPEG only.** Drop the live-stream feature in Obico's control panel; rely solely on JPEG snapshots for AI detection.
+2. **Bundled Janus inside the container** — package Janus binary in the Docker image (`janus-gateway` Alpine package), spawn it from the bridge process, and run a WebSocket relay between local Janus and the Obico server.
+3. **External / sidecar Janus** — require users to run Janus as a separate container or service, configure the bridge to connect to it.
+4. **Direct WebRTC peer connection from the bridge** — implement WebRTC signalling and media in Node.js (e.g. `wrtc`, `mediasoup`).
+
+## Decision Outcome
+
+Chosen: **Option 2 — bundled Janus, with optional Option 3 (hosted/sidecar) supported via `JANUS_MODE` env var**.
+
+The bridge ships Janus inside its Docker image (`janus-gateway` Alpine package) and manages its lifecycle. The camera module emits an H.264 RTP stream; the `janus` module manages the Janus process and signals through a WebSocket relay so the Obico control panel can negotiate a WebRTC peer connection with the local Janus.
+
+`JANUS_MODE=bundled|hosted|auto` covers two operational shapes without forcing users into one:
+
+- **`bundled`** — bridge spawns and supervises its own Janus instance; default for the published Docker image.
+- **`hosted`** — bridge connects to an externally managed Janus (sidecar pattern); used in development on macOS where Janus cannot be installed natively (see `docker-compose.dev.yml`).
+- **`auto`** — detect a running Janus on `ws://127.0.0.1:8188` first, fall back to bundled.
+
+Reasoning: bundled gives the user a one-`docker run` setup without sacrificing the option for advanced users to run their own Janus. The relay isolates the media path from the agent protocol — the WebSocket carrying status/frames stays separate from the Janus signalling channel.
+
+The `JANUS_HOST_IP` env var is required when WebRTC is in use; without it, Janus cannot advertise a reachable ICE candidate to the browser. This is documented in the README and produces a graceful fallback (MJPEG only) when unset.
+
+## Consequences
+
+- **Positive:**
+  - Live-stream parity with Moonraker-Obico and OctoPrint-Obico — Obico control panel "just works."
+  - Sub-second latency for live video.
+  - Single-container deployment for the default case (ADR-0001 preserved).
+  - Separation of concerns: `src/janus/manager.ts` (process lifecycle) vs. `src/janus/relay.ts` (WS relay) — each is independently testable.
+  - macOS development supported via `JANUS_MODE=hosted` and `docker-compose.dev.yml`.
+- **Negative:**
+  - Larger Docker image (Janus + dependencies, ~25 MB compressed).
+  - Operational complexity: extra UDP port range (`10100–10200/udp`) must be published, and `JANUS_HOST_IP` must be set correctly or live stream falls back silently.
+  - Janus is a C dependency we don't control — version bumps require image rebuilds and ARM/AMD64 testing.
+- **Constraint established:**
+  - `src/camera/camera.ts` produces both MJPEG frames (for ADR-0004's snapshot upload path) **and** an H.264 RTP output for Janus. Removing one breaks the other use case.
+  - The Obico WebSocket (status/frames) and the Janus WebSocket (media signalling) are two distinct connections to the Obico server — both must be healthy for full functionality.
+
+## Related Decisions
+
+- ADR-0001 — Docker Single-Container Model (single image, multi-binary).
+- ADR-0002 — OctoPrint Agent Identity for Obico WebSocket (status/frames path).
+- ADR-0004 — RTSP Camera Stream via ffmpeg (camera input shared between MJPEG and RTP output).

--- a/docs/decisions/ADR-0009-frontend-stack.md
+++ b/docs/decisions/ADR-0009-frontend-stack.md
@@ -1,0 +1,70 @@
+# ADR-0009: Frontend Stack — React 19 + Vite + Mantine + react-router + i18next
+
+## Status
+
+Accepted
+
+## Context and Problem Statement
+
+SentryBridge serves a browser-based interface for two flows:
+
+1. **Setup wizard** — a 4-step guided flow (PrusaLink credentials → camera test → Obico pairing → done) that runs once on first start.
+2. **Dashboard** — long-lived monitoring UI showing live status, camera preview, health indicators, and a G-code file browser with upload / print / delete operations.
+
+Both share the same SPA delivered as static assets by the Express backend (`src/server.ts`). The frontend must build into a self-contained `frontend/dist/` that the Docker image copies in. What stack should the frontend use?
+
+## Decision Drivers
+
+- **Self-hosted / offline-friendly** — the bridge often runs on a LAN with no internet access for the _user_; the build must produce static assets with no runtime CDN or telemetry.
+- **Reasonable component coverage out of the box** — wizard forms, dashboard panels, modals, file lists with sort/search, drag-and-drop upload. We don't want to hand-roll a component library.
+- **i18n support** — English and German are first-class (Quality Goal: Operability). Adding more languages later should not require restructuring.
+- **Familiarity for contributors** — public open-source project; React + TypeScript is the path of least resistance for drive-by contributors.
+- **Build speed** — fast iteration during development, fast Docker build in CI.
+- **No SSR / no routing server** — the bridge serves a single SPA from Express; a full Next.js / Remix-style framework would add deployment complexity for no gain.
+- **Bundle size** — ships in a single Docker image; reasonable but not extreme constraint (the image already contains Node.js, ffmpeg, Janus).
+
+## Considered Options
+
+1. **React + Vite + Mantine + react-router + i18next** (chosen).
+2. **React + CRA / Webpack** — slower builds, abandoned tooling direction.
+3. **Vue 3 + Vite + Vuetify / PrimeVue** — fewer drive-by contributors expected vs. React.
+4. **Svelte / SvelteKit** — smaller bundles, but smaller component-library ecosystem and fewer contributors.
+5. **No framework — vanilla HTML + a few scripts** — wizard forms and the file browser are too rich; would slow development.
+
+## Decision Outcome
+
+Chosen: **Option 1 — React + Vite + Mantine + react-router-dom + i18next + react-i18next**.
+
+Concrete pinning (verified against `frontend/package.json`):
+
+| Concern           | Choice                                                                                                 | Rationale                                                                                                                        |
+| ----------------- | ------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
+| Framework         | **React 19** + TypeScript                                                                              | Largest contributor pool; first-class TypeScript ecosystem.                                                                      |
+| Build             | **Vite 8** (`@vitejs/plugin-react`)                                                                    | Fast dev server, fast production builds, simple config.                                                                          |
+| Component library | **Mantine 9** (`@mantine/core`, `@mantine/hooks`)                                                      | Wide component coverage (Stepper, Table, Modal, Dropzone, Notifications) without per-component installs; first-class TypeScript. |
+| Icons             | **`@tabler/icons-react`**                                                                              | Pairs with Mantine's design language; tree-shakeable.                                                                            |
+| Routing           | **`react-router-dom` 7**                                                                               | Wizard / dashboard split; client-side routing only — no SSR.                                                                     |
+| i18n              | **`i18next` + `react-i18next` + `i18next-browser-languagedetector`**                                   | EN/DE support; auto-detect browser language; resource bundles per language under `frontend/src/i18n/`.                           |
+| Backend serving   | **Express 5 static assets** at `/`, API at `/api/*` (`src/server.ts`)                                  | Single-port deployment; no separate frontend server.                                                                             |
+| Dev proxy         | **Vite proxy** (`vite.config.proxy.ts`, `npm run dev:frontend:proxy`) forwards `/api/*` to the backend | No CORS during local development; same URL shape as production.                                                                  |
+
+## Consequences
+
+- **Positive:**
+  - Fast development cycle: `npm run dev:all` runs backend (`ts-node` watch) and Vite dev server in parallel, hot-reload on both.
+  - Mantine covers ~all UI surfaces (Stepper for wizard, Modal for confirmations, Dropzone for upload, Table for file browser) without per-component selection.
+  - Production build is a static bundle copied into the Docker image — no runtime dependency on any external CDN.
+  - i18next resources are simple JSON, easy for contributors to add a new language.
+- **Negative:**
+  - Mantine 9 is a recent major; breaking changes between minors require attention during upgrades.
+  - React 19 + Vite 8 + TypeScript 6 are bleeding-edge versions; some plugins/types may lag during dependency bumps.
+  - Bundle size is ~600 KB minified (gzip ~180 KB) — fine for LAN deployment, larger than a vanilla approach.
+- **Constraint established:**
+  - Pages live under `frontend/src/pages/` (one per route); reusable UI under `frontend/src/components/`; hooks under `frontend/src/hooks/`; i18n under `frontend/src/i18n/`. Don't add nested page routers.
+  - All user-facing strings go through `t()` — no hardcoded English in components.
+  - Backend stays headless: no template rendering, no server-side React. Express only serves the prebuilt SPA and the JSON API.
+
+## Related Decisions
+
+- ADR-0001 — Docker Single-Container Model (frontend builds into the same image).
+- ADR-0006 — Configuration Stored as JSON File on Docker Volume (config UI consumes the same shape).


### PR DESCRIPTION
## Summary

Two architectural decisions that have been validated in the codebase since v1.0 / v1.1.0 were never recorded as ADRs. Backfilled retroactively from `.planning/PROJECT.md` key-decisions and the current source tree:

- **ADR-0008 — Janus WebRTC Relay for Live Stream in Obico Control Panel.** Why Janus is bundled inside the bridge container, why MJPEG alone is insufficient for live video, and how `JANUS_MODE=bundled|hosted|auto` covers production and macOS-dev shapes.
- **ADR-0009 — Frontend Stack (React 19 + Vite + Mantine + react-router + i18next).** The stack that has been in use since v1.0, with drivers (LAN/offline, component coverage, contributor familiarity) and constraints it establishes (page/component/hook layout, `t()` for all user-facing strings, Express stays headless).

`docs/architecture/09-decisions.md` ADR index updated.

No code logic changes.

## Verification

- `npm run typecheck` — clean (docs-only PR, sanity check).
- All cross-references in the ADRs verified against the current source tree (`src/janus/`, `src/camera/`, `frontend/package.json`, `src/server.ts`).

## Follow-up

This PR is part of the `.planning/`-backfill round. Two real product gaps surfaced during the same scan and were filed as separate issues (not closed by this PR):

- #30 — feat: API authentication for `/api/config`, `/api/bridge/*`, `/api/files/*` (NFR-S01 opt-in path).
- #31 — fix: dashboard camera feed drops occasionally during active session (distinct from #9).

## Test plan

- [ ] CI passes
- [ ] No broken markdown links — `grep -r '](../decisions/' docs/`
- [ ] Reviewer confirms the rationale captured in each ADR matches their understanding of why we ended up with Janus and the React/Mantine stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Architecture Decision Records index with new entries
  * Documented live-streaming infrastructure design and deployment approach
  * Documented frontend technology stack and development practices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->